### PR TITLE
Added German Translation as well as a small Bugfix.

### DIFF
--- a/Description.md
+++ b/Description.md
@@ -30,11 +30,21 @@ Spread this extension and help us raise environmental awareness! Let's preserve 
 German (de)
 -----------
 
-Translated by: 
+Translated by: Kolya Opahle | kolpa | https://github.com/kolpa
 
-(Short: ToDo )
+(Kurz: Berechnet den CO2 Ausstoß auf von Google Maps vorgeschlagenen Routen! )
 
-ToDo
+Diese Browsererweiterung berechnet bei jeder Routenplanung mit dem Auto über Google Maps den Erwarteten CO2 Ausstoß und zeigt diesen neben der Gesamtstrecke an.
+
+Um Die Schätzungen zu verbessern können in den Einstellungen Eigenschaften wie Kraftstoffverbrauch und Umweltfreundlichkeit deines Fahrzeuges eingestellt werden.
+
+Sende Kommentare und Frage bitte an MapsCarbonFootprint@gmail.com.
+
+Wenn dir diese Erweiterung gefällt gebe ihr bitte eine gute Bewertung und like sie auf facebook (http://www.facebook.com/pages/Carbon-Footprint-for-Google-Maps/217487891623173) und/oder Google+ (https://plus.google.com/b/112973863308036008385/112973863308036008385/posts).
+
+Teile diese Erweiterung und helfe uns Umweltbewusstsein zu verstärken! Last uns die Umwelt schützen, die Erderwärmung stoppen und unseren Planeten retten!
+
+
 
 Spanish (es)
 ------------

--- a/Source/GoogleMapsCarbonFootprint.js
+++ b/Source/GoogleMapsCarbonFootprint.js
@@ -192,6 +192,7 @@ function getDistanceString(route) {
  *   - the distance of the route, in kilometers.
  */
 function convertDistance(distanceStr) {
+  distanceStr = distanceStr.replace('&nbsp;', ' ');
   var distanceAndUnit = distanceStr.split(/ /);
   var distance = distanceAndUnit[0];
   var unit = distanceAndUnit[1];

--- a/Source/_locales/de/messages.json
+++ b/Source/_locales/de/messages.json
@@ -1,0 +1,68 @@
+{
+	"extName" : {
+		"message" : "CO₂ Fußabdruck für Google Maps™",
+		"description" : "German title"
+	},
+	"extDesc" : {
+		"message" : "Automatische Berechnung von CO₂ Ausstoß auf von Google Maps vorgeschlagenen Fahrtstrecken.",
+		"description" : "German description"
+	},
+	"mainParah" : {
+		"message" : "<p>Diese Browsererweiterung berechnet bei jeder Routenplanung mit dem Auto über Google Maps den Erwarteten CO<sub>2</sub> Ausstoß und zeigt diesen auf der linken Seite der Karte neben der Gesamtstrecke an.</p><p>Fülle einen der Tabs mit den korrekten Informationen aus um die Schätzung zu verbessern: </p>",
+		"description" : "The paragraph beside form"
+	},
+	"fuelConsumption"	: {
+		"message"	: "Kraftstoffverbrauch"
+	},
+	"fuelConsumptionUnit"	: {
+		"message"	: "Kraftstoffverbrauchseinheit"
+	},
+	"fuelEfficiency"	: {
+		"message"	: "Effizienz"
+	},
+	"fuelEfficiencyUnit"	: {
+		"message"	: "Effizienzeinheit"
+	},
+	"coEmission"	: {
+		"message"	: "CO<sub>2</sub> Ausstoß"
+	},
+	"coEmissionUnit" : {
+		"message"	: "CO<sub>2</sub> Ausstoßeinheit"
+	},
+	"fuelType"	: {
+		"message"	: "Kraftstofftyp"
+	},
+	"fuelCost"	: {
+		"message"	: "Kraftstoffpreis"
+	},
+	"fuelCostUnit"	: {
+		"message"	: "$ Pro Einheit"
+	},
+	"fuelCostNote"	: {
+		"message"	: "'$' Ist eine Beispielwährung."
+	},
+	"distance"	: {
+		"message"	: "Enfernung"
+	},
+	"volume"	: {
+		"message"	: "Einheit"
+	},
+	"mass"	: {
+		"message"	: "Masse"
+	},
+	"perVolume"	: {
+		"message"	: "Pro Volumen"
+	},
+	"perDistance"	: {
+		"message"	: "Pro Strecke"
+	},
+	"conversionNote"	: {
+		"message"	: "Verändere die Einheiten um Umzurechnen."
+	},
+	"travelCostEstimate"	: {
+		"message"	: "Reisekostenschätzung anzeigen"
+	},
+	"save" : {
+		"message" : "SPEICHERN"
+	}
+}

--- a/Source/_locales/en/messages.json
+++ b/Source/_locales/en/messages.json
@@ -59,6 +59,9 @@
 	"conversionNote"	: {
 		"message"	: "To get conversions change the units."
 	},
+	"travelCostEstimate"	: {
+		"message"	: "Display travel cost estimation"
+	},
 	"save" : {
 		"message" : "SAVE"
 	}

--- a/Source/options.html
+++ b/Source/options.html
@@ -135,7 +135,7 @@
                     </div>
                     <div class="form-group">
                         <input type="checkbox" id="display-travel-cost" unchecked>  
-                        <label for="display-travel-cost">Display travel cost estimation</label>
+                        <label for="display-travel-cost" data-language="travelCostEstimate">Display travel cost estimation</label>
                     </div>
                     <div class="form-group">
                         <button id="save-button" data-language="save" >Save</button>  


### PR DESCRIPTION
This should fix an error that was occuring on the German Version of Google Maps which was using a nbsp between the distance count and the unit resulting in the breaking of the split function in the original version.

I have also added the German Translation in reference to #12 and created one new localisation string.

@Ceilican is the Translation of the fuel type names something we want to do aswell?