### PR TITLE
Replacing deprecated chrome API

### DIFF
--- a/Source/BingMapsCarbonFootprint.js
+++ b/Source/BingMapsCarbonFootprint.js
@@ -14,7 +14,7 @@ var href = location.href;
 console.log('Location: ' + href);
 
 if (href.match(/mapspreview/gi)) {
-  chrome.extension.sendRequest({carbonEmission: 'Request Carbon Efficiency...'}, function(response) {
+  chrome.runtime.sendMessage({carbonEmission: 'Request Carbon Efficiency...'}, function(response) {
     // alert("got response from background: " + response);
   
     travelRate = response.travelRate.value;

--- a/Source/GoogleMapsCarbonFootprint.js
+++ b/Source/GoogleMapsCarbonFootprint.js
@@ -14,7 +14,7 @@ var href = location.href;
 console.log('Location: ' + href);
 
 if (href.match(/maps/gi)) {
-  chrome.extension.sendRequest({carbonEmission: 'Request Carbon Efficiency...'}, function(response) {
+  chrome.runtime.sendMessage({carbonEmission: 'Request Carbon Efficiency...'}, function(response) {
 
     travelRate = response.travelRate.value;
     displayTravelCost = response.travelRate.displayTravelCost;

--- a/Source/OpenMapsCarbonFootprint.js
+++ b/Source/OpenMapsCarbonFootprint.js
@@ -14,7 +14,7 @@ var href = location.href;
 console.log('Location: ' + href);
 
 if (href.match(/directions/gi)) {
-  chrome.extension.sendRequest({carbonEmission: 'Request Carbon Efficiency...'}, function(response) {
+  chrome.runtime.sendMessage({carbonEmission: 'Request Carbon Efficiency...'}, function(response) {
     // alert("got response from background: " + response);
     console.log(response);
 

--- a/Source/background.js
+++ b/Source/background.js
@@ -24,7 +24,7 @@ function initializeLocalStorage() {
 
 initializeLocalStorage();
 
-function onRequest(request, sender, sendResponse) {
+function onMessage(request, sender, sendResponse) {
   console.log('Request Received');
   if (request.carbonEmission) {
     console.log('Show pageAction icon in tab: ' + sender.tab.id);
@@ -34,7 +34,7 @@ function onRequest(request, sender, sendResponse) {
   }
 };
 
-chrome.extension.onRequest.addListener(onRequest);
+chrome.runtime.onMessage.addListener(onMessage);
 
 function pageActionClicked() {
   chrome.tabs.create({url: chrome.extension.getURL('options.html')});


### PR DESCRIPTION
Hi @Ceilican 

The chrome.extension.sendRequest [API has been deprecated](https://developer.chrome.com/extensions/extension#method-sendRequest) and has been replaced by chrome.runtime.sendMessage.

This change involves patch to the following files:
1. Source/background.js
2. Source/BingMapsCarbonFootprint.js
3. Source/GoogleMapsCarbonFootprint.js
4. Source/OpenMapsCarbonFootprint.js

Thanks
C