### PR TITLE
Important Fix

### DIFF
--- a/Source/core/init.js
+++ b/Source/core/init.js
@@ -22,7 +22,7 @@ new SettingsProvider(function(settingsProvider) {
       attributes: true,
       childList: true,
       characterData: true,
-      subtree: false
+      subtree: true
     });
   });
 });


### PR DESCRIPTION
Hi @Ceilican,

I think the optimisation done in #55 is not right. The footprints were not being showed under certain circumstances.

Replicating the error: Click on _Details_ of the selected route in Google Maps. Next, click back and you'll find the footprints to be gone.

Regards