### PR TITLE
public transport emssions for heremaps

### DIFF
--- a/Source/core/maps/BingMapsManager.js
+++ b/Source/core/maps/BingMapsManager.js
@@ -188,8 +188,7 @@ BingMapsManager.prototype.update = function() {
     var timeInHrs = this.convertTime(timeString);
     this.insertFootprintElement(
       transitRoutes[i],
-      this.footprintCore.createPTFootprintElement(timeInHrs),
-      't'
+      this.footprintCore.createPTFootprintElement(timeInHrs)
     );
   }
 };

--- a/Source/core/maps/HereMapsManager.js
+++ b/Source/core/maps/HereMapsManager.js
@@ -27,6 +27,8 @@ var HereMapsManager = function(footprintCore, settingsProvider) {
 
 HereMapsManager.prototype.getMode = function(route) {
   // var mode = route.getAttribute('data-mode');
+  if(!route.classList[1])
+    return 'pt';
   var mode = route.classList[1].match(/route_card_(.*)/)[1];
   console.log('Route mode: ' + mode);
   return mode;
@@ -39,11 +41,28 @@ HereMapsManager.prototype.getMode = function(route) {
 
 HereMapsManager.prototype.getAllDrivingRoutes = function() {
   var routes = [];
-
   // Get all non-transit driving routes suggested by Here Maps. route_card
   var r = document.getElementsByClassName('route_card');
   for (var i = r.length - 1; i >= 0; i--) { // Filtering spurious routes.
     if (this.getMode(r[i]) == 'car') {
+      routes.push(r[i]);
+    }
+  }
+  console.log(routes);
+  return routes;
+};
+
+/**
+ * Gets transit routes.
+ * @return {string} routes
+ */
+
+HereMapsManager.prototype.getAllTransitRoutes = function() {
+  var routes = [];
+  // Get all transit driving routes suggested by Here Maps. route_card
+  var r = document.getElementsByClassName('route_card');
+  for (var i = r.length - 1; i >= 0; i--) { // Filtering spurious routes.
+    if (this.getMode(r[i]) == 'pt') {
       routes.push(r[i]);
     }
   }
@@ -64,6 +83,19 @@ HereMapsManager.prototype.getDistanceString = function(route) {
 };
 
 /**
+ * Gets time for transit route.
+ * @param {object} route
+ * @return {string} timeString
+ */
+
+HereMapsManager.prototype.getTimeString = function(route) {
+  var timeString = route.getElementsByClassName('duration')[0].textContent;
+  timeString = ' ' + timeString;
+  console.log('timeString:' + timeString);
+  return timeString;
+};
+
+/**
  * Converts Distance.
  * @param {string} distanceStr
  * @return {float} distanceFloat
@@ -75,6 +107,35 @@ HereMapsManager.prototype.convertDistance = function(distanceStr) {
     var distance = distanceAndUnit[0];
     var unit = distanceAndUnit[1];
     return this.footprintCore.getDistanceFromStrings(distance, unit);
+  }
+};
+
+/**
+ * Converts total time into hours.
+ * @param {string} timeStr
+ * @return {float} hrs
+ */
+
+HereMapsManager.prototype.convertTime = function(timeStr) {
+  if (timeStr) {
+    var days = (/ (\w*)d/).exec(timeStr);
+    var hrs = (/ (\w*)h/).exec(timeStr);
+    var mins = (/ (\w*)m/).exec(timeStr);
+    if(hrs){
+      hrs = parseFloat(hrs[1]);
+    }
+    else{
+      hrs = 0;
+    }
+    if(mins){
+      mins = parseFloat(mins[1]);
+      hrs += mins/60;
+    }
+    if(days){
+      days = parseFloat(days[1]);
+      hrs += days*24;
+    }
+    return hrs;
   }
 };
 
@@ -121,20 +182,30 @@ HereMapsManager.prototype.insertTravelCostElement = function(route, e) {
 
 HereMapsManager.prototype.update = function() {
   var thisMap = this;
-  var routes = thisMap.getAllDrivingRoutes();
-    for (var i = 0; i < routes.length; i++) {
-      var distanceString = thisMap.getDistanceString(routes[i]);
-        var distanceInKm = thisMap.convertDistance(distanceString);
-      thisMap.insertFootprintElement(
-        routes[i],
-        thisMap.footprintCore.createFootprintElement(distanceInKm)
+  var drivingRoutes = thisMap.getAllDrivingRoutes();
+  var i;
+  for (i = 0; i < drivingRoutes.length; i++) {
+    var distanceString = thisMap.getDistanceString(drivingRoutes[i]);
+    var distanceInKm = thisMap.convertDistance(distanceString);
+    thisMap.insertFootprintElement(
+      drivingRoutes[i],
+      thisMap.footprintCore.createFootprintElement(distanceInKm)
+    );
+    if (thisMap.settingsProvider.showTravelCost())
+      thisMap.insertTravelCostElement(
+        drivingRoutes[i],
+        thisMap.footprintCore.createTravelCostElement(distanceInKm)
       );
-      if (thisMap.settingsProvider.showTravelCost())
-        thisMap.insertTravelCostElement(
-          routes[i],
-          thisMap.footprintCore.createTravelCostElement(distanceInKm)
-        );
-    }
+  }
+  var transitRoutes = thisMap.getAllTransitRoutes();
+  for (i = 0; i < transitRoutes.length; i++) {
+    var timeString = this.getTimeString(transitRoutes[i]);
+    var timeInHrs = ' ' + this.convertTime(timeString);
+    thisMap.insertFootprintElement(
+      transitRoutes[i],
+      this.footprintCore.createPTFootprintElement(timeInHrs)
+    );
+  }
 };
 
 var MapManager = HereMapsManager;


### PR DESCRIPTION
Hi @Ceilican,

After Prateek fixed the map managers in his last PR, I tried adding support for displaying of public transport emission for remaining map managers. I have added support for HereMaps but however, I wasn't able to do this for MapQuest and OpenStreet maps since I wasn't able to get any transit info on my system. They do provide it for some cities though. I tried searching for routes in these cities but to no avail. Even using VPN to mock my location turned out to be a futile attempt.

[This](http://wiki.openstreetmap.org/wiki/Public_transport#Public_transports_by_country) page shows that transit routes are available for Germany for OpenStreet maps and maybe for MapQuest too. So I will have to bother @Kolpa to get this done.